### PR TITLE
RFP-004, RFP-020: add LEZ programs TWAP reference to Resources

### DIFF
--- a/RFPs/RFP-004-privacy-preserving-dex.md
+++ b/RFPs/RFP-004-privacy-preserving-dex.md
@@ -384,6 +384,8 @@ All code must be released under the **MIT+Apache2.0 dual License**.
 ## Resources
 
 - [Logos Documentation](https://github.com/logos-co/logos-docs)
+- [LEZ programs](https://github.com/logos-blockchain/lez-programs): on-chain
+  TWAP program reference implementation
 
 ## ✏️ How to Apply
 

--- a/RFPs/RFP-020-redstone-oracle-adaptor.md
+++ b/RFPs/RFP-020-redstone-oracle-adaptor.md
@@ -742,6 +742,8 @@ All code must be released under the **MIT+Apache2.0 dual License**.
   collateral path)
 - [RFP-019 — On-Chain TWAP Oracle](./RFP-019-twap-oracle.md) (defines the
   canonical oracle price account standard)
+- [LEZ programs](https://github.com/logos-blockchain/lez-programs): on-chain
+  TWAP program reference implementation
 - [Appendix: Oracle Ecosystem](../appendix/oracle-ecosystem.md)
 - [RedStone Documentation](https://docs.redstone.finance/)
 - [RedStone token registry](https://github.com/redstone-finance/redstone-api/blob/main/docs/ALL_SUPPORTED_TOKENS.md)


### PR DESCRIPTION
Adds the on-chain TWAP program reference implementation ([logos-blockchain/lez-programs](https://github.com/logos-blockchain/lez-programs)) to the Resources section of the two RFPs that integrate the TWAP component directly:

- **RFP-004** (Privacy-Preserving DEX) — hooks the TWAP accumulator into its pools
- **RFP-020** (RedStone Oracle Adaptor) — populates the same canonical oracle price account standard, paired with the TWAP tier on the consumer side

RFP-019 is intentionally excluded: the lez-programs TWAP program *is* RFP-019's implementation, so self-referencing it as a resource makes no sense. RFP-008/013/014 are also excluded, where TWAP is only an alternative once a DEX is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)