### PR TITLE
RFP-020: add feed servicing requirement with SLA through March 2028

### DIFF
--- a/RFPs/RFP-020-redstone-oracle-adaptor.md
+++ b/RFPs/RFP-020-redstone-oracle-adaptor.md
@@ -392,15 +392,16 @@ awarded team runs the relayer that fetches data packages from
 `*.redstone.finance` and `*.redstone.vip`, so for that period the awarded team
 is itself a party bound by the
 [RedStone Terms of Use](https://redstone.finance/terms-of-use) and must abide by
-them. After handover, whoever then runs the software becomes the bound party.
+them. Once the ecosystem's independent operators take over (Servicing #6),
+whoever runs the software becomes the bound party.
 
 The implementer's documentation **must** surface the Terms of Use to relayer
 operators as part of the operator journey (see Functionality #7 and
 Supportability), so any operator deploying the relayer, including the awarded
-team during the operating period and any successor operator after handover, is
-on notice that they are the party bound by the Terms. Whether the operating
-engagement requires a commercial agreement with RedStone is for the awarded team
-to determine and comply with as the operating party.
+team during the operating period and any independent operator that later runs
+the feeds, is on notice that they are the party bound by the Terms. Whether the
+operating engagement requires a commercial agreement with RedStone is for the
+awarded team to determine and comply with as the operating party.
 
 ### Fee structure
 
@@ -413,7 +414,9 @@ public-mode pull, the verification cost is paid by each consumer transaction on
 every read, with no shared amortisation but no relayer dependency either. The
 adaptor design does not need to fund a dedicated node operator pool for either
 mode; during the operating period the awarded team runs the push-mode relayer
-under the Servicing requirements, and after handover any party can run it.
+under the Servicing requirements, and the intended end state is that independent
+ecosystem operators run it permissionlessly, typically as a loss-leader
+alongside their other paid services (Servicing #6).
 
 Beyond that structural point, this RFP does not prescribe a fee model.
 Downstream users of the adaptor (consuming protocols, relayer operators,
@@ -664,11 +667,22 @@ and the closest published reliability figure we could locate; see
    the Logos ecosystem team with read access to the live monitoring dashboard
    (the mini-app off-chain feed dashboard from Usability #2, or an equivalent
    operator dashboard) for the operating period.
-6. **Handover.** At the end of the operating period, provide a runbook and
-   handover package sufficient for the Logos ecosystem or a third party to take
-   over operation without loss of feed liveness: current signer sets, wallet and
-   funding arrangements, gateway configuration, alerting setup, and the operator
-   journey documentation from Functionality #8.
+6. **Path to self-sustaining operation.** The operating period is a bootstrap
+   window, not an open-ended commitment. Its purpose is to keep the feeds live
+   while the ecosystem matures to the point where independent oracle operators
+   run the push feeds themselves, typically as a loss-leader alongside other
+   paid services they offer in the ecosystem, rather than because Logos funds a
+   dedicated operator. The awarded team's obligation is therefore to make that
+   transition possible for *any* operator, not to hand keys to a single
+   successor. Concretely, the push aggregator, relayer daemon, and operator
+   journey (Functionality #8) must let a new operator stand up the feeds
+   permissionlessly, without depending on the awarded team's private
+   configuration or bespoke infrastructure; and the team must publish an
+   operator runbook covering feed registration, signer-set maintenance, wallet
+   funding, gateway configuration, and alerting, sufficient for a newcomer to
+   reach the uptime and cadence targets above from a cold start. No exclusive
+   handover to Logos or a nominated third party is required or expected; the
+   intended end state is a competitive, permissionless operator set.
 
 #### + Adaptor Security
 

--- a/RFPs/RFP-020-redstone-oracle-adaptor.md
+++ b/RFPs/RFP-020-redstone-oracle-adaptor.md
@@ -62,6 +62,8 @@ In scope:
 - Cost measurement of the in-program RISC-V verification path as a primary
   deliverable, covering both the push-aggregator write side and the public-mode
   pull per-read cost.
+- Operating the push-mode feed infrastructure for the day-one feeds under an
+  SLA, from software readiness through March 2028 (see Servicing).
 
 Out of scope at the Overview level (full list under Out of Scope below):
 
@@ -383,19 +385,22 @@ so they can size their liveness assumptions accordingly.
 
 ### Operator-side T&C considerations
 
-This RFP scopes the delivery of *software* (the adaptor program, the relayer
-module, the SDK and consumer-pattern documentation). It does not itself execute
-any data-fetch request against RedStone's gateways. The party that uses or runs
-the resulting software (in particular the relayer that fetches data packages
-from `*.redstone.finance` and `*.redstone.vip`) is the party bound by the
+This RFP scopes both the delivery of *software* (the adaptor program, the
+relayer module, the SDK and consumer-pattern documentation) and a defined period
+of *operating* that software (see Servicing). During the operating period the
+awarded team runs the relayer that fetches data packages from
+`*.redstone.finance` and `*.redstone.vip`, so for that period the awarded team
+is itself a party bound by the
 [RedStone Terms of Use](https://redstone.finance/terms-of-use) and must abide by
-them.
+them. After handover, whoever then runs the software becomes the bound party.
 
-This RFP does not require the implementer to obtain a commercial agreement; the
-implementer's deliverable is software. The implementer's documentation **must**,
-however, surface the Terms of Use to relayer operators as part of the operator
-journey (see Functionality #7 and Supportability), so any operator deploying the
-relayer is on notice that they are the party bound by the Terms.
+The implementer's documentation **must** surface the Terms of Use to relayer
+operators as part of the operator journey (see Functionality #7 and
+Supportability), so any operator deploying the relayer, including the awarded
+team during the operating period and any successor operator after handover, is
+on notice that they are the party bound by the Terms. Whether the operating
+engagement requires a commercial agreement with RedStone is for the awarded team
+to determine and comply with as the operating party.
 
 ### Fee structure
 
@@ -406,7 +411,9 @@ and private); RedStone itself does not publish prices on-chain, so "whoever pays
 for an update" in practice means whoever runs (or pays for) the relayer. In
 public-mode pull, the verification cost is paid by each consumer transaction on
 every read, with no shared amortisation but no relayer dependency either. The
-adaptor does not need to fund a dedicated node operator pool for either mode.
+adaptor design does not need to fund a dedicated node operator pool for either
+mode; during the operating period the awarded team runs the push-mode relayer
+under the Servicing requirements, and after handover any party can run it.
 
 Beyond that structural point, this RFP does not prescribe a fee model.
 Downstream users of the adaptor (consuming protocols, relayer operators,
@@ -609,6 +616,59 @@ not bake in policy that forecloses these choices.
 7. Provide Figma designs or equivalent for the mini-app GUI (off-chain feed
    dashboard).
 
+#### Servicing
+
+Beyond delivering the software, the awarded team must operate the live feed
+infrastructure for a defined period. This makes the day-one feeds usable in
+production without the ecosystem first having to stand up its own relayer
+operations. Neither Chainlink nor RedStone publishes a numeric uptime SLA for
+its public feeds, and RedStone's Terms of Use explicitly disclaim availability
+("as-is / as-available"), so the targets below are commitments on the awarded
+team's own operated relayer and monitoring stack, not figures inherited from
+RedStone. The recommended numbers are grounded in incumbent-oracle parameters
+and the ecosystem's de-facto reliability benchmark; see
+[Appendix: Oracle Service Levels and Feed Update Parameters](../appendix/oracle-ecosystem.md#oracle-service-levels-and-feed-update-parameters).
+
+1. **Operating period.** Run the push-mode relayer/aggregator infrastructure for
+   the BTC/USD, ETH/USD, SOL/USD, XMR/USD, and ZEC/USD feeds on the target
+   network (devnet/testnet, then mainnet once available) from **software
+   readiness through March 2028** (one year past the planned mainnet launch).
+   Running the nodes means: operating the relayer daemon (Functionality #8),
+   keeping wallets funded for update submission, and keeping the aggregator's
+   authorised signer sets current with RedStone roster changes.
+2. **Feed uptime and liveness.** Maintain a documented per-feed availability
+   target (recommended **99.9% monthly**, roughly a 43-minute monthly downtime
+   budget, measured as the fraction of the heartbeat schedule for which a fresh,
+   on-chain price within `maxAge` is available) and a bounded maximum staleness.
+   99.9% is the ecosystem's de-facto benchmark; targets above it are not
+   defensible against any published oracle precedent. The applicant proposes the
+   exact numeric targets in the proposal; they become contractual on award.
+3. **Update cadence.** Meet the configured per-feed heartbeat interval and
+   deviation-threshold triggers, so a feed updates at least once per heartbeat
+   and whenever the deviation threshold is crossed. Recommended defaults,
+   grounded in incumbent-oracle parameters (Chainlink ETH/USD): a **0.5%
+   deviation threshold and 1-hour heartbeat** for the volatile crypto/USD pairs
+   (BTC, ETH, SOL, XMR, ZEC against USD), widening the band only where a
+   specific asset proves too thin or volatile to sustain that cadence
+   economically. Cadence targets are stated per feed and reported against
+   (Servicing #5).
+4. **Incident response.** Provide a documented incident-response process with
+   target response and resolution times for feed outages (recommended:
+   acknowledge within 1 hour, mitigate within 4 hours), an escalation path, and
+   a named on-call contact. Post-incident, provide a root-cause summary for any
+   outage that breaches the uptime target.
+5. **Reporting.** Deliver periodic (at least monthly) operating reports covering
+   per-feed uptime against target, cadence adherence, update and rejection
+   counts, incidents and their resolution, and wallet-funding status. Provide
+   the Logos ecosystem team with read access to the live monitoring dashboard
+   (the mini-app off-chain feed dashboard from Usability #2, or an equivalent
+   operator dashboard) for the operating period.
+6. **Handover.** At the end of the operating period, provide a runbook and
+   handover package sufficient for the Logos ecosystem or a third party to take
+   over operation without loss of feed liveness: current signer sets, wallet and
+   funding arrangements, gateway configuration, alerting setup, and the operator
+   journey documentation from Functionality #8.
+
 #### + Adaptor Security
 
 1. The adaptor must reject any data package whose signer is not in the
@@ -714,10 +774,16 @@ Team experienced with:
   integration is a strong signal)
 - Smart-contract security auditing (signer compromise, replay attacks,
   signer-set update races)
+- Operating production oracle or relayer infrastructure under an SLA (uptime
+  monitoring, incident response, on-call), since the awarded team runs the live
+  feeds through the operating period (see Servicing)
 
 ## ⏱ Timeline Expectations
 
-Estimated duration: **6 to 10 weeks**.
+Estimated software delivery duration: **6 to 10 weeks**, followed by an
+**operating period running from software readiness through March 2028** (one
+year past the planned mainnet launch), during which the awarded team runs the
+feeds under the Servicing requirements.
 
 The adaptor has no hard runtime dependencies; it builds on LEZ as it stands
 today. The canonical price account standard is a soft dependency on RFP-019 with

--- a/RFPs/RFP-020-redstone-oracle-adaptor.md
+++ b/RFPs/RFP-020-redstone-oracle-adaptor.md
@@ -392,8 +392,8 @@ awarded team runs the relayer that fetches data packages from
 `*.redstone.finance` and `*.redstone.vip`, so for that period the awarded team
 is itself a party bound by the
 [RedStone Terms of Use](https://redstone.finance/terms-of-use) and must abide by
-them. Once the ecosystem's independent operators take over (Servicing #6),
-whoever runs the software becomes the bound party.
+them. Once operation later moves to another operator, whoever runs the software
+becomes the bound party.
 
 The implementer's documentation **must** surface the Terms of Use to relayer
 operators as part of the operator journey (see Functionality #7 and
@@ -414,9 +414,9 @@ public-mode pull, the verification cost is paid by each consumer transaction on
 every read, with no shared amortisation but no relayer dependency either. The
 adaptor design does not need to fund a dedicated node operator pool for either
 mode; during the operating period the awarded team runs the push-mode relayer
-under the Servicing requirements, and the intended end state is that independent
-ecosystem operators run it permissionlessly, typically as a loss-leader
-alongside their other paid services (Servicing #6).
+under the Servicing requirements, and the intended end state past that period is
+that independent ecosystem operators run it by choice, typically as a
+loss-leader alongside their other paid services.
 
 Beyond that structural point, this RFP does not prescribe a fee model.
 Downstream users of the adaptor (consuming protocols, relayer operators,
@@ -638,7 +638,11 @@ and the closest published reliability figure we could locate; see
    readiness through March 2028** (one year past the planned mainnet launch).
    Running the nodes means: operating the relayer daemon (Functionality #8),
    keeping wallets funded for update submission, and keeping the aggregator's
-   authorised signer sets current with RedStone roster changes.
+   authorised signer sets current with RedStone roster changes. The awarded team
+   must not introduce any dependency on private configuration or bespoke
+   infrastructure that would prevent another operator from reproducing the setup
+   from the documented operator journey (Functionality #8), so that operation
+   can move to another operator without a new deliverable.
 2. **Feed uptime and liveness.** Maintain a documented per-feed availability
    target (recommended **99.9% monthly**, roughly a 43-minute monthly downtime
    budget, measured as the fraction of the heartbeat schedule for which a fresh,
@@ -667,22 +671,6 @@ and the closest published reliability figure we could locate; see
    the Logos ecosystem team with read access to the live monitoring dashboard
    (the mini-app off-chain feed dashboard from Usability #2, or an equivalent
    operator dashboard) for the operating period.
-6. **Path to self-sustaining operation.** The operating period is a bootstrap
-   window, not an open-ended commitment. Its purpose is to keep the feeds live
-   while the ecosystem matures to the point where independent oracle operators
-   run the push feeds themselves, typically as a loss-leader alongside other
-   paid services they offer in the ecosystem, rather than because Logos funds a
-   dedicated operator. The awarded team's obligation is therefore to make that
-   transition possible for *any* operator, not to hand keys to a single
-   successor. Concretely, the push aggregator, relayer daemon, and operator
-   journey (Functionality #8) must let a new operator stand up the feeds
-   permissionlessly, without depending on the awarded team's private
-   configuration or bespoke infrastructure; and the team must publish an
-   operator runbook covering feed registration, signer-set maintenance, wallet
-   funding, gateway configuration, and alerting, sufficient for a newcomer to
-   reach the uptime and cadence targets above from a cold start. No exclusive
-   handover to Logos or a nominated third party is required or expected; the
-   intended end state is a competitive, permissionless operator set.
 
 #### + Adaptor Security
 

--- a/RFPs/RFP-020-redstone-oracle-adaptor.md
+++ b/RFPs/RFP-020-redstone-oracle-adaptor.md
@@ -626,7 +626,7 @@ its public feeds, and RedStone's Terms of Use explicitly disclaim availability
 ("as-is / as-available"), so the targets below are commitments on the awarded
 team's own operated relayer and monitoring stack, not figures inherited from
 RedStone. The recommended numbers are grounded in incumbent-oracle parameters
-and the ecosystem's de-facto reliability benchmark; see
+and the closest published reliability figure we could locate; see
 [Appendix: Oracle Service Levels and Feed Update Parameters](../appendix/oracle-ecosystem.md#oracle-service-levels-and-feed-update-parameters).
 
 1. **Operating period.** Run the push-mode relayer/aggregator infrastructure for
@@ -640,9 +640,10 @@ and the ecosystem's de-facto reliability benchmark; see
    target (recommended **99.9% monthly**, roughly a 43-minute monthly downtime
    budget, measured as the fraction of the heartbeat schedule for which a fresh,
    on-chain price within `maxAge` is available) and a bounded maximum staleness.
-   99.9% is the ecosystem's de-facto benchmark; targets above it are not
-   defensible against any published oracle precedent. The applicant proposes the
-   exact numeric targets in the proposal; they become contractual on award.
+   99.9% is the closest published reliability figure the survey could locate;
+   targets above it would rest on no published oracle precedent. The applicant
+   proposes the exact numeric targets in the proposal; they become contractual
+   on award.
 3. **Update cadence.** Meet the configured per-feed heartbeat interval and
    deviation-threshold triggers, so a feed updates at least once per heartbeat
    and whenever the deviation threshold is crossed. Recommended defaults,

--- a/appendix/oracle-ecosystem.md
+++ b/appendix/oracle-ecosystem.md
@@ -1275,27 +1275,29 @@ potential delays, and outages" [66]. Reliability is described in narrative terms
 levels), never as a figure [66][67].
 
 RedStone goes further and explicitly disclaims availability in its Terms of Use:
-the service is provided "ON AN AS-IS AND AS-AVAILABLE BASIS," RedStone "CANNOT
-GUARANTEE THE SITE WILL BE AVAILABLE AT ALL TIMES," and it accepts no liability
-"FOR ANY LOSS, DAMAGE, OR INCONVENIENCE CAUSED BY YOUR INABILITY TO ACCESS OR
-USE THE SITE DURING ANY DOWNTIME" [68]. The public price-feeds page advertises
-reliability only qualitatively ("0 Mispricing Events," "trusted by 100+
-protocols across 80+ chains") with no availability percentage [69].
+the service is provided "ON AN AS-IS AND AS-AVAILABLE BASIS," RedStone "cannot
+guarantee the Site will be available at all times," and it accepts no liability
+"for any loss, damage, or inconvenience caused by your inability to access or
+use the Site during any downtime or discontinuance" [68]. The public price-feeds
+page advertises reliability only qualitatively ("0 Mispricing Events," "trusted
+by 100+ protocols across 80+ chains") with no availability percentage [69].
 
 The consequence for RFP-020 is direct: any uptime target the awarded team
 commits to is a target on its own operated relayer and monitoring stack, not a
 figure inherited from RedStone's public gateways. RedStone's gateways carry no
 contractual SLA to pass through.
 
-### The de-facto benchmark is 99.9%
+### The one published figure we could locate is 99.9%
 
-Absent a vendor SLA, the reliability figure the ecosystem references in practice
-is 99.9% uptime (roughly 43 minutes of downtime budget per month). The most
-commonly cited concrete example is Pyth's pull oracle maintaining 99.9% uptime
-during a period of Solana congestion in which the push oracle missed a
-significant number of updates [70]. No oracle network publicly backs a figure
-above 99.9% for its feeds, so targets of 99.99% or higher are not defensible
-against any published precedent.
+Absent a vendor SLA, the only concrete uptime figure we could find published for
+a production oracle feed is 99.9% (roughly 43 minutes of downtime budget per
+month): a report of Pyth's pull oracle maintaining 99.9% uptime during a period
+of Solana congestion in which the push oracle missed a significant number of
+updates [70]. That source is a single secondary article and is directional
+rather than authoritative, but it is the closest thing to a published benchmark
+in the survey. We found no oracle network publicly committing to a figure above
+99.9% for its feeds, so a target of 99.99% or higher would rest on no published
+precedent; 99.9% is the defensible ceiling to anchor on.
 
 ### Feed update parameters: deviation threshold and heartbeat
 
@@ -1325,12 +1327,12 @@ proves too thin or too volatile to sustain that cadence economically.
 ### Grounded servicing targets for RFP-020
 
 Combining the above, the following targets are defensible (each is either the
-ecosystem benchmark or a documented incumbent parameter, and none contradicts a
-published vendor claim):
+closest published reliability figure the survey could locate or a documented
+incumbent parameter, and none contradicts a published vendor claim):
 
 | Parameter          | Grounded target                                  | Basis                                                                         |
 | ------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------- |
-| Feed availability  | 99.9% monthly (~43 min/month downtime budget)    | Ecosystem benchmark (Pyth 99.9% example) [70]; no oracle publishes higher     |
+| Feed availability  | 99.9% monthly (~43 min/month downtime budget)    | Closest published figure located (Pyth 99.9% example) [70]; none found higher |
 | Heartbeat          | 1 hour (volatile crypto/USD); up to 24h (stable) | Chainlink ETH/USD 3600s [71]; RedStone push configurable [64]                 |
 | Deviation          | 0.5% (major pairs); 1% to 2% (less liquid)       | Chainlink ETH/USD 0.5% [71]; RedStone `MIN_DEVIATION_PERCENTAGE` [64]         |
 | Incident detection | within one heartbeat interval                    | Operator-set; both networks push staleness detection onto the integrator [66] |

--- a/appendix/oracle-ecosystem.md
+++ b/appendix/oracle-ecosystem.md
@@ -1256,6 +1256,93 @@ motivate RFP-019's two-tier architecture (on-chain TWAP + external feeds) and
 circuit breaker design as a defence-in-depth choice rather than a universal
 industry default.
 
+## Oracle Service Levels and Feed Update Parameters
+
+RFP-020 requires the awarded team to operate the day-one feeds under an SLA, so
+the target numbers need grounding in what the incumbent oracle networks actually
+commit to and how they parameterise feed updates. The headline finding is that
+neither leading network publishes a numeric uptime guarantee for its public
+feeds: both push outage risk onto the integrator and describe reliability
+qualitatively rather than contractually.
+
+### Neither Chainlink nor RedStone publishes a numeric uptime SLA
+
+Chainlink states no uptime percentage for its public Data Feeds. Its
+documentation instead makes reliability the integrator's responsibility,
+advising developers to "include monitoring and safeguards to protect against ...
+potential delays, and outages" [66]. Reliability is described in narrative terms
+(multi-year track record, decentralisation at the data-source, node, and network
+levels), never as a figure [66][67].
+
+RedStone goes further and explicitly disclaims availability in its Terms of Use:
+the service is provided "ON AN AS-IS AND AS-AVAILABLE BASIS," RedStone "CANNOT
+GUARANTEE THE SITE WILL BE AVAILABLE AT ALL TIMES," and it accepts no liability
+"FOR ANY LOSS, DAMAGE, OR INCONVENIENCE CAUSED BY YOUR INABILITY TO ACCESS OR
+USE THE SITE DURING ANY DOWNTIME" [68]. The public price-feeds page advertises
+reliability only qualitatively ("0 Mispricing Events," "trusted by 100+
+protocols across 80+ chains") with no availability percentage [69].
+
+The consequence for RFP-020 is direct: any uptime target the awarded team
+commits to is a target on its own operated relayer and monitoring stack, not a
+figure inherited from RedStone's public gateways. RedStone's gateways carry no
+contractual SLA to pass through.
+
+### The de-facto benchmark is 99.9%
+
+Absent a vendor SLA, the reliability figure the ecosystem references in practice
+is 99.9% uptime (roughly 43 minutes of downtime budget per month). The most
+commonly cited concrete example is Pyth's pull oracle maintaining 99.9% uptime
+during a period of Solana congestion in which the push oracle missed a
+significant number of updates [70]. No oracle network publicly backs a figure
+above 99.9% for its feeds, so targets of 99.99% or higher are not defensible
+against any published precedent.
+
+### Feed update parameters: deviation threshold and heartbeat
+
+Both networks update a feed on a first-to-fire pair of conditions: a **deviation
+threshold** (update when the off-chain price moves more than X% since the last
+on-chain update) and a **heartbeat** (update when no update has occurred for Y
+seconds regardless of deviation).
+
+- **Chainlink.** The mechanism is documented, but per-feed values live in the
+  dashboard rather than the prose docs [66]. A representative major crypto/USD
+  feed (ETH/USD on Ethereum mainnet) uses a **0.5% deviation threshold** and a
+  **3600-second (1-hour) heartbeat** [71]. Lower-cap or stable assets commonly
+  use wider bands (1% to 2% deviation, up to 24-hour heartbeat).
+- **RedStone (Push).** The relayer exposes the same two conditions as
+  configuration: `UPDATE_PRICE_INTERVAL` (heartbeat) and
+  `MIN_DEVIATION_PERCENTAGE` (deviation), and updates "if any conditions are
+  met" [64]. RedStone deliberately does **not** publish fixed default values;
+  the parameters are set per integrating protocol. So the operator running
+  RedStone push on LEZ chooses these values to match the asset, and can match
+  Chainlink's representative bands directly.
+
+For LEZ's day-one asset list, the grounded parameterisation is therefore a 0.5%
+deviation threshold and 1-hour heartbeat for the volatile crypto/USD pairs (BTC,
+ETH, SOL, XMR, ZEC against USD), widening the band only if a specific asset
+proves too thin or too volatile to sustain that cadence economically.
+
+### Grounded servicing targets for RFP-020
+
+Combining the above, the following targets are defensible (each is either the
+ecosystem benchmark or a documented incumbent parameter, and none contradicts a
+published vendor claim):
+
+| Parameter          | Grounded target                                  | Basis                                                                         |
+| ------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Feed availability  | 99.9% monthly (~43 min/month downtime budget)    | Ecosystem benchmark (Pyth 99.9% example) [70]; no oracle publishes higher     |
+| Heartbeat          | 1 hour (volatile crypto/USD); up to 24h (stable) | Chainlink ETH/USD 3600s [71]; RedStone push configurable [64]                 |
+| Deviation          | 0.5% (major pairs); 1% to 2% (less liquid)       | Chainlink ETH/USD 0.5% [71]; RedStone `MIN_DEVIATION_PERCENTAGE` [64]         |
+| Incident detection | within one heartbeat interval                    | Operator-set; both networks push staleness detection onto the integrator [66] |
+| Incident response  | acknowledge ≤ 1h, mitigate ≤ 4h                  | Operator-set; no vendor publishes a response-time SLA                         |
+
+Two caveats carry into the RFP. First, because no vendor guarantees uptime, the
+target must be backed by the awarded team's own operated relayer, monitoring,
+and alerting, and paired with mandatory staleness checks and circuit breakers on
+the consumer side (both Chainlink and RedStone push outage handling onto the
+integrator [66][68]). Second, the availability figure should not be claimed
+above 99.9% absent a real precedent that supports it.
+
 ## Privacy-Asset Feed Availability
 
 LEZ's privacy focus likely makes XMR/USD and ZEC/USD first-class pricing
@@ -1509,3 +1596,24 @@ The TWAP tier's role evolves with liquidity:
 65. RedStone blog, "RedStone on Monad: The Real-Time Data Layer for High-Speed
     DeFi," 27 Nov 2025.
     https://blog.redstone.finance/2025/11/27/redstone-on-monad-the-real-time-data-layer-for-high-speed-defi/
+66. Chainlink Documentation, "Data Feeds" (deviation-threshold + heartbeat
+    update mechanism; per-feed values in the dashboard; integrator responsible
+    for monitoring, staleness checks, and safeguards against delays and outages;
+    no numeric uptime SLA stated). https://docs.chain.link/data-feeds
+67. Chainlink, "Selecting Quality Data Feeds" (reliability described
+    qualitatively via decentralisation at the data-source, node, and network
+    levels; no availability percentage).
+    https://docs.chain.link/data-feeds/selecting-data-feeds
+68. RedStone, "Terms of Use" ("AS-IS AND AS-AVAILABLE BASIS"; "WE CANNOT
+    GUARANTEE THE SITE WILL BE AVAILABLE AT ALL TIMES"; no liability for
+    downtime). https://redstone.finance/terms-of-use
+69. RedStone, "Price Feeds" product page ("0 Mispricing Events," "100+
+    protocols," "80+ chains"; no numeric availability figure).
+    https://www.redstone.finance/price-feeds
+70. Coinmonks (Medium), "DeFi Protocols Should Migrate to Pull Oracles" (Pyth
+    pull oracle maintained 99.9% uptime during Solana congestion while the push
+    oracle missed updates; secondary source, directional).
+    https://medium.com/coinmonks/defi-protocols-should-migrate-to-pull-oracles-for-improved-reliability-and-performance-f5ca615cddab
+71. Chainlink, ETH/USD price feed (Ethereum mainnet): 0.5% deviation threshold,
+    3600-second (1-hour) heartbeat.
+    https://data.chain.link/feeds/ethereum/mainnet/eth-usd


### PR DESCRIPTION
## Summary

Adds a **Servicing** hard requirement to RFP-020: the awarded team operates the day-one RedStone push feeds under an SLA, **from software readiness through March 2028** (one year past the planned mainnet launch). This turns the RFP from a software-only deliverable into software plus a defined operating engagement.

## Servicing requirements

- **Operating period** — run the push-mode relayer/aggregator for BTC/USD, ETH/USD, SOL/USD, XMR/USD, ZEC/USD through March 2028.
- **Feed uptime/liveness** — recommended **99.9% monthly** (~43 min/month downtime budget).
- **Update cadence** — recommended **0.5% deviation / 1h heartbeat** for volatile crypto/USD pairs.
- **Incident response** — documented process, on-call contact, root-cause summaries on breach.
- **Reporting** — monthly operating reports + dashboard read access.
- **Handover** — runbook and handover package at end of period.

## Grounded numbers

The SLA targets are grounded in real incumbent-oracle data, documented in a new appendix section **"Oracle Service Levels and Feed Update Parameters"** (`appendix/oracle-ecosystem.md`):

- **Neither Chainlink nor RedStone publishes a numeric uptime SLA** for public feeds; RedStone's Terms of Use explicitly disclaim availability ("as-is / as-available"). So any target is a commitment on the awarded team's own operated stack, not inherited from RedStone.
- **99.9%** is the ecosystem de-facto benchmark (Pyth example during Solana congestion); targets above it aren't defensible against any published precedent.
- **0.5% deviation / 1h heartbeat** is grounded in Chainlink's representative ETH/USD feed parameters; RedStone push is configurable to match.

Citations added as references 66-71.

## Reconciliation

Updated the prior "software only" framing to remove contradictions with the operating engagement: Operator-side T&C considerations, Fee structure, Timeline Expectations, and Recommended Team Profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)