### PR TITLE
ci: sync RFP proposals to tracking board (#17)

### DIFF
--- a/.github/workflows/add-under-review-to-board.yml
+++ b/.github/workflows/add-under-review-to-board.yml
@@ -1,0 +1,67 @@
+name: Add under-review proposals to board
+
+# When an issue in this repo is labeled `under-review`, add it to the
+# "RFP & LPrize Tracking" org project (#17) and set its Status to
+# "Proposal review". The default GITHUB_TOKEN cannot write to org-level
+# Projects v2, so this uses a PAT stored as the PROJECTS_PAT secret
+# (classic PAT with `repo` + `project`, or a fine-grained PAT with
+# Organization projects: Read & write and Issues: Read).
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-proposal-review:
+    if: github.event.label.name == 'under-review'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECTS_PAT }}
+          script: |
+            const ORG = 'logos-co';
+            const PROJECT_NUMBER = 17;
+            const TARGET_STATUS = 'Proposal review';
+            const issueNodeId = context.payload.issue.node_id;
+
+            // 1. Resolve project id, Status field id, and the target option id
+            //    (looked up by name so it survives option-id regeneration).
+            const meta = await github.graphql(`
+              query($org:String!, $num:Int!) {
+                organization(login:$org){
+                  projectV2(number:$num){
+                    id
+                    field(name:"Status"){
+                      ... on ProjectV2SingleSelectField { id options { id name } }
+                    }
+                  }
+                }
+              }`, { org: ORG, num: PROJECT_NUMBER });
+
+            const project = meta.organization.projectV2;
+            const statusField = project.field;
+            const option = statusField.options.find(o => o.name === TARGET_STATUS);
+            if (!option) { core.setFailed(`No Status option named "${TARGET_STATUS}"`); return; }
+
+            // 2. Add the issue to the project (idempotent: returns the existing
+            //    item if it is already on the board, without duplicating).
+            const added = await github.graphql(`
+              mutation($project:ID!, $content:ID!) {
+                addProjectV2ItemById(input:{projectId:$project, contentId:$content}){ item { id } }
+              }`, { project: project.id, content: issueNodeId });
+            const itemId = added.addProjectV2ItemById.item.id;
+
+            // 3. Set Status = Proposal review.
+            await github.graphql(`
+              mutation($project:ID!, $item:ID!, $field:ID!, $opt:String!) {
+                updateProjectV2ItemFieldValue(input:{
+                  projectId:$project, itemId:$item, fieldId:$field,
+                  value:{ singleSelectOptionId:$opt }
+                }){ projectV2Item { id } }
+              }`, { project: project.id, item: itemId, field: statusField.id, opt: option.id });
+
+            core.info(`Issue #${context.payload.issue.number} → "${TARGET_STATUS}".`);

--- a/.github/workflows/add-under-review-to-board.yml
+++ b/.github/workflows/add-under-review-to-board.yml
@@ -2,10 +2,12 @@ name: Sync RFP proposals to tracking board
 
 # Keeps the "RFP & LPrize Tracking" org project (#17) in sync with proposal
 # issues in this repo:
-#   * label `proposal`      -> add to board as "Received Proposals"
-#                              (ONLY if not already on the board in another
-#                              column — never overrides an existing status)
-#   * label `under-review`  -> move to "Priority review" (always)
+#   * label `proposal`      -> add to board as "Received Proposals", but ONLY
+#                              if the issue does NOT already carry `under-review`
+#                              and is not already on the board in another column
+#                              (never overrides an existing status).
+#   * label `under-review`  -> move to "Priority review" (always).
+# Net effect: "Received Proposals" = has `proposal`, not yet `under-review`.
 #
 # The default GITHUB_TOKEN cannot write to org-level Projects v2, so this uses
 # a PAT stored as the PROJECTS_PAT secret (classic PAT with `repo` + `project`,
@@ -32,6 +34,8 @@ jobs:
             const label = context.payload.label.name;
             const issueNodeId = context.payload.issue.node_id;
             const issueNumber = context.payload.issue.number;
+            const issueLabels = (context.payload.issue.labels || [])
+              .map(l => (typeof l === 'string' ? l : l.name));
 
             // Target column per label.
             const TARGET = label === 'under-review' ? 'Priority review' : 'Received Proposals';
@@ -78,6 +82,13 @@ jobs:
             const currentStatus = boardItem && boardItem.fieldValueByName
               ? boardItem.fieldValueByName.name : null;
 
+            // For `proposal`: it belongs in "Received Proposals" only while it
+            // has NOT yet been moved to review. If it already carries
+            // `under-review`, that path owns it — do nothing here.
+            if (label === 'proposal' && issueLabels.includes('under-review')) {
+              core.info(`#${issueNumber} already has under-review — not a Received Proposal.`);
+              return;
+            }
             // For `proposal`: never override an item that already sits in a
             // column. Only place brand-new / status-less items.
             if (label === 'proposal' && currentStatus) {

--- a/.github/workflows/add-under-review-to-board.yml
+++ b/.github/workflows/add-under-review-to-board.yml
@@ -1,11 +1,15 @@
-name: Add under-review proposals to board
+name: Sync RFP proposals to tracking board
 
-# When an issue in this repo is labeled `under-review`, add it to the
-# "RFP & LPrize Tracking" org project (#17) and set its Status to
-# "Priority review". The default GITHUB_TOKEN cannot write to org-level
-# Projects v2, so this uses a PAT stored as the PROJECTS_PAT secret
-# (classic PAT with `repo` + `project`, or a fine-grained PAT with
-# Organization projects: Read & write and Issues: Read).
+# Keeps the "RFP & LPrize Tracking" org project (#17) in sync with proposal
+# issues in this repo:
+#   * label `proposal`      -> add to board as "Received Proposals"
+#                              (ONLY if not already on the board in another
+#                              column — never overrides an existing status)
+#   * label `under-review`  -> move to "Priority review" (always)
+#
+# The default GITHUB_TOKEN cannot write to org-level Projects v2, so this uses
+# a PAT stored as the PROJECTS_PAT secret (classic PAT with `repo` + `project`,
+# or a fine-grained PAT with Organization projects: Read & write + Issues: Read).
 
 on:
   issues:
@@ -15,8 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  add-to-proposal-review:
-    if: github.event.label.name == 'under-review'
+  sync:
+    if: github.event.label.name == 'proposal' || github.event.label.name == 'under-review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -25,11 +29,15 @@ jobs:
           script: |
             const ORG = 'logos-co';
             const PROJECT_NUMBER = 17;
-            const TARGET_STATUS = 'Priority review';
+            const label = context.payload.label.name;
             const issueNodeId = context.payload.issue.node_id;
+            const issueNumber = context.payload.issue.number;
 
-            // 1. Resolve project id, Status field id, and the target option id
-            //    (looked up by name so it survives option-id regeneration).
+            // Target column per label.
+            const TARGET = label === 'under-review' ? 'Priority review' : 'Received Proposals';
+
+            // 1. Resolve project id, Status field id, and option ids (by name,
+            //    so this survives Projects option-id regeneration).
             const meta = await github.graphql(`
               query($org:String!, $num:Int!) {
                 organization(login:$org){
@@ -44,18 +52,46 @@ jobs:
 
             const project = meta.organization.projectV2;
             const statusField = project.field;
-            const option = statusField.options.find(o => o.name === TARGET_STATUS);
-            if (!option) { core.setFailed(`No Status option named "${TARGET_STATUS}"`); return; }
+            const option = statusField.options.find(o => o.name === TARGET);
+            if (!option) { core.setFailed(`No Status option named "${TARGET}"`); return; }
 
-            // 2. Add the issue to the project (idempotent: returns the existing
-            //    item if it is already on the board, without duplicating).
+            // 2. Is this issue already on the board, and does it have a status?
+            const existing = await github.graphql(`
+              query($id:ID!) {
+                node(id:$id){
+                  ... on Issue {
+                    projectItems(first:20){
+                      nodes{
+                        id
+                        project{ id }
+                        fieldValueByName(name:"Status"){
+                          ... on ProjectV2ItemFieldSingleSelectValue { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`, { id: issueNodeId });
+
+            const boardItem = (existing.node.projectItems.nodes || [])
+              .find(n => n.project && n.project.id === project.id);
+            const currentStatus = boardItem && boardItem.fieldValueByName
+              ? boardItem.fieldValueByName.name : null;
+
+            // For `proposal`: never override an item that already sits in a
+            // column. Only place brand-new / status-less items.
+            if (label === 'proposal' && currentStatus) {
+              core.info(`#${issueNumber} already on board in "${currentStatus}" — leaving as is.`);
+              return;
+            }
+
+            // 3. Add to the project (idempotent) and set the target status.
             const added = await github.graphql(`
               mutation($project:ID!, $content:ID!) {
                 addProjectV2ItemById(input:{projectId:$project, contentId:$content}){ item { id } }
               }`, { project: project.id, content: issueNodeId });
             const itemId = added.addProjectV2ItemById.item.id;
 
-            // 3. Set Status = Proposal review.
             await github.graphql(`
               mutation($project:ID!, $item:ID!, $field:ID!, $opt:String!) {
                 updateProjectV2ItemFieldValue(input:{
@@ -64,4 +100,4 @@ jobs:
                 }){ projectV2Item { id } }
               }`, { project: project.id, item: itemId, field: statusField.id, opt: option.id });
 
-            core.info(`Issue #${context.payload.issue.number} → "${TARGET_STATUS}".`);
+            core.info(`#${issueNumber} → "${TARGET}".`);

--- a/.github/workflows/add-under-review-to-board.yml
+++ b/.github/workflows/add-under-review-to-board.yml
@@ -7,6 +7,7 @@ name: Sync RFP proposals to tracking board
 #                              and is not already on the board in another column
 #                              (never overrides an existing status).
 #   * label `under-review`  -> move to "Priority review" (always).
+#   * label `rejected`      -> move to "Rejected proposals" (always; terminal).
 # Net effect: "Received Proposals" = has `proposal`, not yet `under-review`.
 #
 # The default GITHUB_TOKEN cannot write to org-level Projects v2, so this uses
@@ -22,7 +23,7 @@ permissions:
 
 jobs:
   sync:
-    if: github.event.label.name == 'proposal' || github.event.label.name == 'under-review'
+    if: github.event.label.name == 'proposal' || github.event.label.name == 'under-review' || github.event.label.name == 'rejected'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -38,7 +39,10 @@ jobs:
               .map(l => (typeof l === 'string' ? l : l.name));
 
             // Target column per label.
-            const TARGET = label === 'under-review' ? 'Priority review' : 'Received Proposals';
+            const TARGET =
+              label === 'under-review' ? 'Priority review'
+              : label === 'rejected'   ? 'Rejected proposals'
+              : 'Received Proposals';
 
             // 1. Resolve project id, Status field id, and option ids (by name,
             //    so this survives Projects option-id regeneration).

--- a/.github/workflows/add-under-review-to-board.yml
+++ b/.github/workflows/add-under-review-to-board.yml
@@ -2,7 +2,7 @@ name: Add under-review proposals to board
 
 # When an issue in this repo is labeled `under-review`, add it to the
 # "RFP & LPrize Tracking" org project (#17) and set its Status to
-# "Proposal review". The default GITHUB_TOKEN cannot write to org-level
+# "Priority review". The default GITHUB_TOKEN cannot write to org-level
 # Projects v2, so this uses a PAT stored as the PROJECTS_PAT secret
 # (classic PAT with `repo` + `project`, or a fine-grained PAT with
 # Organization projects: Read & write and Issues: Read).
@@ -25,7 +25,7 @@ jobs:
           script: |
             const ORG = 'logos-co';
             const PROJECT_NUMBER = 17;
-            const TARGET_STATUS = 'Proposal review';
+            const TARGET_STATUS = 'Priority review';
             const issueNodeId = context.payload.issue.node_id;
 
             // 1. Resolve project id, Status field id, and the target option id


### PR DESCRIPTION
## What

GitHub Actions workflow that keeps org project **#17 (RFP & LPrize Tracking)** in sync with proposal issues:

- Label **`proposal`** → add to board as **Received Proposals** — *only if the issue isn't already on the board in another column* (never overrides an existing status).
- Label **`under-review`** → move to **Priority review** (always).

## Why

Proposals should surface on the tracking board automatically, giving leadership live visibility without manual board upkeep.

## How it works

- Trigger: `issues: [labeled]`, gated to `proposal` / `under-review`.
- Resolves the project, `Status` field, and target option **by name at runtime**, so it survives Projects option-ID regeneration.
- Checks the issue's existing board item/status first; `addProjectV2ItemById` is idempotent (no duplicates).
- Add-only: removing a label does nothing (by design).

## Required setup (before it works)

Add repo secret **`PROJECTS_PAT`**:
- Classic PAT with `repo` + `project`, **or**
- Fine-grained PAT with **Organization projects: Read & write** + **Issues: Read** for `logos-co`.

The default `GITHUB_TOKEN` cannot write to org-level Projects v2, hence the PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)